### PR TITLE
Use both ES modules and CommonJS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-/packages/*/lib
+/packages/*/dist-*
+/packages/cli/dist
 coverage
 node_modules
 *.log

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -1,0 +1,15 @@
+const { compilerOptions } = require("@tsconfig/recommended/tsconfig.json");
+
+module.exports = {
+  collectCoverageFrom: ["src/**/*.ts", "!src/**/index.ts"],
+  coverageReporters: ["lcov", "text", "text-summary"],
+  globals: {
+    "ts-jest": {
+      tsconfig: {
+        ...compilerOptions,
+      },
+    },
+  },
+  preset: "ts-jest",
+  testEnvironment: "node",
+};

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "coverage:aggregate": "lerna-lcov-aggregate"
   },
   "devDependencies": {
+    "@tsconfig/recommended": "^1.0.1",
     "coveralls": "^3.1.1",
     "lerna": "^4.0.0",
     "lerna-lcov-aggregate": "^1.0.0"

--- a/packages/cli/bin/nobolog
+++ b/packages/cli/bin/nobolog
@@ -1,7 +1,10 @@
 #!/usr/bin/env node
 
-const path = require('path');
-const fs = require('fs');
-const lib = path.join(path.dirname(fs.realpathSync(__filename)), '../lib');
+const path = require("path");
+const fs = require("fs");
 
-require(lib).run();
+require(path.join(
+  path.dirname(fs.realpathSync(__filename)),
+  "..",
+  "dist"
+)).run();

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,7 +29,7 @@
     "node": ">=12.0"
   },
   "scripts": {
-    "clean": "rimraf './lib'",
+    "clean": "rimraf './dist'",
     "build": "tsc",
     "watch": "tsc -w",
     "lint": "eslint './src/**/*.ts'",
@@ -39,6 +39,7 @@
   "dependencies": {
     "@nobolog/runtime": "^0.1.1",
     "ts-command-line-args": "^2.2.0",
+    "tslib": "^2.3.1",
     "version": "^0.1.2"
   },
   "devDependencies": {

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,8 +1,10 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.cjs.json",
   "compilerOptions": {
-    "declaration": false,
-    "outDir": "./lib"
+    "baseUrl": ".",
+    "outDir": "./dist",
+    "rootDir": "src"
   },
-  "include": ["./src/**/*.ts"]
+  "include": ["./src/**/*.ts"],
+  "exclude": ["./src/**/*.test.ts"]
 }

--- a/packages/lexer/jest.config.js
+++ b/packages/lexer/jest.config.js
@@ -1,0 +1,5 @@
+const base = require("../../jest.config.base");
+
+module.exports = {
+  ...base,
+};

--- a/packages/lexer/jest.config.json
+++ b/packages/lexer/jest.config.json
@@ -1,6 +1,0 @@
-{
-  "collectCoverageFrom": ["src/**/*.ts", "!src/**/index.ts"],
-  "coverageReporters": ["lcov", "text", "text-summary"],
-  "preset": "ts-jest",
-  "testEnvironment": "node"
-}

--- a/packages/lexer/package.json
+++ b/packages/lexer/package.json
@@ -16,19 +16,22 @@
   "bugs": {
     "url": "https://github.com/RauliL/nobolog/issues"
   },
-  "main": "./lib/index.js",
+  "main": "./dist-cjs/index.js",
   "main:src": "./src/index.ts",
-  "types": "./lib/index.d.ts",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.js",
   "files": [
-    "./lib"
+    "./dist-*"
   ],
   "engines": {
     "node": ">=12.0"
   },
   "scripts": {
-    "clean": "rimraf './lib'",
-    "build": "tsc",
-    "watch": "tsc -w",
+    "clean": "rimraf './dist-*'",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
+    "build:es": "tsc -p tsconfig.es.json",
+    "build:types": "tsc -p tsconfig.types.json",
     "lint": "eslint './src/**/*.ts'",
     "test": "jest",
     "test:coverage": "jest --coverage",
@@ -39,6 +42,7 @@
     "@types/jest": "^27.4.0",
     "@typescript-eslint/eslint-plugin": "^5.9.1",
     "@typescript-eslint/parser": "^5.9.1",
+    "concurrently": "^7.0.0",
     "eslint": "^8.6.0",
     "eslint-plugin-prettier": "^4.0.0",
     "jest": "^27.4.7",
@@ -48,5 +52,8 @@
     "typescript": "^4.5.4",
     "yarn": "^1.22.17"
   },
-  "gitHead": "28748280d1e34011785db74201187411d3178fbf"
+  "gitHead": "28748280d1e34011785db74201187411d3178fbf",
+  "dependencies": {
+    "tslib": "^2.3.1"
+  }
 }

--- a/packages/lexer/tsconfig.cjs.json
+++ b/packages/lexer/tsconfig.cjs.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "outDir": "dist-cjs",
+    "rootDir": "src"
+  },
+  "extends": "../../tsconfig.cjs.json",
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/lexer/tsconfig.es.json
+++ b/packages/lexer/tsconfig.es.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "outDir": "dist-es",
+    "rootDir": "src"
+  },
+  "extends": "../../tsconfig.es.json",
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/lexer/tsconfig.json
+++ b/packages/lexer/tsconfig.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./lib"
-  },
-  "include": ["./src/**/*.ts"],
-  "exclude": ["./src/**/*.test.ts"]
-}

--- a/packages/lexer/tsconfig.types.json
+++ b/packages/lexer/tsconfig.types.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "declarationDir": "dist-types",
+    "rootDir": "src"
+  },
+  "extends": "../../tsconfig.types.json",
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/parser/jest.config.js
+++ b/packages/parser/jest.config.js
@@ -1,0 +1,5 @@
+const base = require("../../jest.config.base");
+
+module.exports = {
+  ...base,
+};

--- a/packages/parser/jest.config.json
+++ b/packages/parser/jest.config.json
@@ -1,6 +1,0 @@
-{
-  "collectCoverageFrom": ["src/**/*.ts", "!src/**/index.ts"],
-  "coverageReporters": ["lcov", "text", "text-summary"],
-  "preset": "ts-jest",
-  "testEnvironment": "node"
-}

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -16,19 +16,22 @@
   "bugs": {
     "url": "https://github.com/RauliL/nobolog/issues"
   },
-  "main": "./lib/index.js",
+  "main": "./dist-cjs/index.js",
   "main:src": "./src/index.ts",
-  "types": "./lib/index.d.ts",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.js",
   "files": [
-    "./lib"
+    "./dist-*"
   ],
   "engines": {
     "node": ">=12.0"
   },
   "scripts": {
-    "clean": "rimraf './lib'",
-    "build": "tsc",
-    "watch": "tsc -w",
+    "clean": "rimraf './dist-*'",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
+    "build:es": "tsc -p tsconfig.es.json",
+    "build:types": "tsc -p tsconfig.types.json",
     "lint": "eslint './src/**/*.ts'",
     "test": "jest",
     "test:coverage": "jest --coverage",
@@ -36,12 +39,14 @@
     "prepack": "yarn run build"
   },
   "dependencies": {
-    "@nobolog/lexer": "^0.1.1"
+    "@nobolog/lexer": "^0.1.1",
+    "tslib": "^2.3.1"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@typescript-eslint/eslint-plugin": "^5.9.1",
     "@typescript-eslint/parser": "^5.9.1",
+    "concurrently": "^7.0.0",
     "eslint": "^8.6.0",
     "eslint-plugin-prettier": "^4.0.0",
     "jest": "^27.4.7",

--- a/packages/parser/tsconfig.cjs.json
+++ b/packages/parser/tsconfig.cjs.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "outDir": "dist-cjs",
+    "rootDir": "src"
+  },
+  "extends": "../../tsconfig.cjs.json",
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/parser/tsconfig.es.json
+++ b/packages/parser/tsconfig.es.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "outDir": "dist-es",
+    "rootDir": "src"
+  },
+  "extends": "../../tsconfig.es.json",
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/parser/tsconfig.json
+++ b/packages/parser/tsconfig.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./lib"
-  },
-  "include": ["./src/**/*.ts"],
-  "exclude": ["./src/**/*.test.ts"]
-}

--- a/packages/parser/tsconfig.types.json
+++ b/packages/parser/tsconfig.types.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "declarationDir": "dist-types",
+    "rootDir": "src"
+  },
+  "extends": "../../tsconfig.types.json",
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/runtime/jest.config.js
+++ b/packages/runtime/jest.config.js
@@ -1,0 +1,5 @@
+const base = require("../../jest.config.base");
+
+module.exports = {
+  ...base,
+};

--- a/packages/runtime/jest.config.json
+++ b/packages/runtime/jest.config.json
@@ -1,6 +1,0 @@
-{
-  "collectCoverageFrom": ["src/**/*.ts", "!src/**/index.ts"],
-  "coverageReporters": ["lcov", "text", "text-summary"],
-  "preset": "ts-jest",
-  "testEnvironment": "node"
-}

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -16,19 +16,22 @@
   "bugs": {
     "url": "https://github.com/RauliL/nobolog/issues"
   },
-  "main": "./lib/index.js",
+  "main": "./dist-cjs/index.js",
   "main:src": "./src/index.ts",
-  "types": "./lib/index.d.ts",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.js",
   "files": [
-    "./lib"
+    "./dist-*"
   ],
   "engines": {
     "node": ">=12.0"
   },
   "scripts": {
-    "clean": "rimraf './lib'",
-    "build": "tsc",
-    "watch": "tsc -w",
+    "clean": "rimraf './dist-*'",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
+    "build:es": "tsc -p tsconfig.es.json",
+    "build:types": "tsc -p tsconfig.types.json",
     "lint": "eslint './src/**/*.ts'",
     "test": "jest",
     "test:coverage": "jest --coverage",
@@ -36,12 +39,14 @@
     "prepack": "yarn run build"
   },
   "dependencies": {
-    "@nobolog/parser": "^0.1.1"
+    "@nobolog/parser": "^0.1.1",
+    "tslib": "^2.3.1"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@typescript-eslint/eslint-plugin": "^5.9.1",
     "@typescript-eslint/parser": "^5.9.1",
+    "concurrently": "^7.0.0",
     "eslint": "^8.6.0",
     "eslint-plugin-prettier": "^4.0.0",
     "jest": "^27.4.7",

--- a/packages/runtime/tsconfig.cjs.json
+++ b/packages/runtime/tsconfig.cjs.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "outDir": "dist-cjs",
+    "rootDir": "src"
+  },
+  "extends": "../../tsconfig.cjs.json",
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/runtime/tsconfig.es.json
+++ b/packages/runtime/tsconfig.es.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "outDir": "dist-es",
+    "rootDir": "src"
+  },
+  "extends": "../../tsconfig.es.json",
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/runtime/tsconfig.json
+++ b/packages/runtime/tsconfig.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./lib"
-  },
-  "include": ["./src/**/*.ts"],
-  "exclude": ["./src/**/*.test.ts"]
-}

--- a/packages/runtime/tsconfig.types.json
+++ b/packages/runtime/tsconfig.types.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "declarationDir": "dist-types",
+    "rootDir": "src"
+  },
+  "extends": "../../tsconfig.types.json",
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "importHelpers": true,
+    "module": "commonjs",
+    "noEmitHelpers": true,
+    "strict": true,
+    "target": "ES2018"
+  }
+}

--- a/tsconfig.es.json
+++ b/tsconfig.es.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "importHelpers": true,
+    "module": "esnext",
+    "noEmitHelpers": true,
+    "strict": true,
+    "target": "es5"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,14 @@
 {
   "compilerOptions": {
-    "target": "es2015",
-    "module": "commonjs",
-    "strict": true,
+    "baseUrl": ".",
     "esModuleInterop": true,
-    "declaration": true,
-    "lib": ["es2018"]
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "paths": {
+      "@nobolog/*": ["packages/*/src"]
+    },
+    "removeComments": true,
+    "resolveJsonModule": true,
+    "target": "ES5"
   }
 }

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "removeComments": false,
+    "strict": true
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1392,6 +1392,11 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
+"@tsconfig/recommended@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@tsconfig/recommended/-/recommended-1.0.1.tgz#7619bad397e06ead1c5182926c944e0ca6177f52"
+  integrity sha512-2xN+iGTbPBEzGSnVp/Hd64vKJCJWxsi9gfs88x4PPMyEjHJoA3o5BY9r5OLPHIZU2pAQxkSAsJFqn6itClP8mQ==
+
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.14":
   version "7.1.18"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.18.tgz#1a29abcc411a9c05e2094c98f9a1b7da6cdf49f8"
@@ -2249,6 +2254,20 @@ concat-stream@^2.0.0:
     readable-stream "^3.0.2"
     typedarray "^0.0.6"
 
+concurrently@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/concurrently/-/concurrently-7.0.0.tgz#78d31b441cec338dab03316c221a2f9a67c529b0"
+  integrity sha512-WKM7PUsI8wyXpF80H+zjHP32fsgsHNQfPLw/e70Z5dYkV7hF+rf8q3D+ScWJIEr57CpkO3OWBko6hwhQLPR8Pw==
+  dependencies:
+    chalk "^4.1.0"
+    date-fns "^2.16.1"
+    lodash "^4.17.21"
+    rxjs "^6.6.3"
+    spawn-command "^0.0.2-1"
+    supports-color "^8.1.0"
+    tree-kill "^1.2.2"
+    yargs "^16.2.0"
+
 config-chain@^1.1.12:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.13.tgz#fad0795aa6a6cdaff9ed1b68e9dff94372c232f4"
@@ -2429,6 +2448,11 @@ data-urls@^2.0.0:
     abab "^2.0.3"
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
+
+date-fns@^2.16.1:
+  version "2.28.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.28.0.tgz#9570d656f5fc13143e50c975a3b6bbeb46cd08b2"
+  integrity sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==
 
 dateformat@^3.0.0:
   version "3.0.3"
@@ -4477,7 +4501,7 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "^3.0.0"
 
-lodash@^4.17.15, lodash@^4.17.19, lodash@^4.7.0:
+lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -5747,7 +5771,7 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-rxjs@^6.6.0:
+rxjs@^6.6.0, rxjs@^6.6.3:
   version "6.6.7"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
   integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
@@ -5913,6 +5937,11 @@ source-map@^0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
+
+spawn-command@^0.0.2-1:
+  version "0.0.2-1"
+  resolved "https://registry.yarnpkg.com/spawn-command/-/spawn-command-0.0.2-1.tgz#62f5e9466981c1b796dc5929937e11c9c6921bd0"
+  integrity sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=
 
 spdx-correct@^3.0.0:
   version "3.1.1"
@@ -6123,7 +6152,7 @@ supports-color@^7.0.0, supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-supports-color@^8.0.0:
+supports-color@^8.0.0, supports-color@^8.1.0:
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
   integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
@@ -6304,6 +6333,11 @@ tr46@~0.0.3:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
 
+tree-kill@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
+  integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
+
 trim-newlines@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
@@ -6337,6 +6371,11 @@ tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tsutils@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
Tweak TypeScript configurations and `package.json` files so that the
built packages contain both ES modules and CommonJS versions of the
package.